### PR TITLE
docs(contribution-guidelines): update Nx version  

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,5 +45,6 @@
     "scss",
     "pcss",
     "postcss"
-  ]
+  ],
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/apps/docs/src/content/docs/contribution-guidelines/index.mdx
+++ b/apps/docs/src/content/docs/contribution-guidelines/index.mdx
@@ -132,7 +132,7 @@ npm i -g pnpm
     Install [Nx](https://nx.dev).
 
 ```sh title="Terminal"
-pnpm i -g nx@latest
+pnpm i -g nx@19.5.7
 ```
 
     Nice, now you're an


### PR DESCRIPTION
- Nx contained different versions (latest: 19.6.2 in contrast to 19.5.7), which were conflicting each other when cloning the repo. Fixed the docs to make sure to download the specific 19.5.7 version instead of the latest version
- Made VSCode recognize the TypeScript version to use

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the contribution guidelines to specify a fixed Nx version for installation, ensuring consistency in the development environment.

Documentation:
- Update the contribution guidelines to specify the installation of Nx version 19.5.7 instead of the latest version.

<!-- Generated by sourcery-ai[bot]: end summary -->