### PR TITLE
test(docs-e2e): add mobile and tablet tests for docs site

### DIFF
--- a/.github/workflows/BUILD.yml
+++ b/.github/workflows/BUILD.yml
@@ -33,6 +33,9 @@ jobs:
       - name: 🧹 Lint Projects
         run: pnpm i; pnpm nx run-many -t lint -p docs docs-e2e website website-e2e portal portal-e2e --verbose
 
+      - name: 🎭 Install Playwright Browsers
+        run: pnpm exec playwright install --with-deps
+
       - name: 🏗️ Build Projects
         run: pnpm nx run-many -t build -p docs website portal --verbose
 

--- a/.github/workflows/TEST_e2e.yml
+++ b/.github/workflows/TEST_e2e.yml
@@ -34,15 +34,37 @@ jobs:
       - name: 🎭 Install Playwright Browsers
         run: pnpm i; pnpm playwright install --with-deps
 
-      - name: 💀 Run E2E Tests
-        run: pnpm nx run-many -t e2e -p docs-e2e website-e2e portal-e2e --parallel=false --verbose
+      - name: 💀 Run Docs E2E Tests
+        run: pnpm nx run docs-e2e:e2e --reporter=html --verbose
 
-      - name: 📄 Upload Artifact
+      - name: 📄 Upload Docs E2E Playwright Report
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report
-          path: playwright-report/
+          name: playwright-report-docs-e2e
+          path: playwright-report/**/*
+          retention-days: 30
+
+      - name: 💀 Run Portal E2E Tests
+        run: pnpm nx run portal-e2e:e2e --reporter=html --verbose
+
+      - name: 📄 Upload Portal E2E Playwright Report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report-portal-e2e
+          path: playwright-report/**/*
+          retention-days: 30
+
+      - name: 💀 Run Website E2E Tests
+        run: pnpm nx run website-e2e:e2e --reporter=html --verbose
+
+      - name: 📄 Upload Website E2E Playwright Report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report-website-e2e
+          path: playwright-report/**/*
           retention-days: 30
 
       - name: 💰 Profit

--- a/.github/workflows/TEST_e2e.yml
+++ b/.github/workflows/TEST_e2e.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/apps/docs-e2e/playwright.config.ts
+++ b/apps/docs-e2e/playwright.config.ts
@@ -23,6 +23,7 @@ const baseURL = process.env.BASE_URL || 'http://127.0.0.1:3000'
 export default defineConfig({
   ...nxE2EPreset(__filename, { testDir: './src' }),
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  retries: 2,
   use: {
     baseURL,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
@@ -34,6 +35,7 @@ export default defineConfig({
     url: 'http://127.0.0.1:3000',
     reuseExistingServer: !process.env.CI,
     cwd: workspaceRoot,
+    timeout: 120 * 1000,
   },
   projects: [
     {

--- a/apps/docs-e2e/playwright.config.ts
+++ b/apps/docs-e2e/playwright.config.ts
@@ -37,38 +37,28 @@ export default defineConfig({
   },
   projects: [
     {
-      name: 'chromium',
+      name: 'chromium (desktop)',
       use: { ...devices['Desktop Chrome'] },
     },
-
     {
-      name: 'firefox',
+      name: 'firefox (desktop)',
       use: { ...devices['Desktop Firefox'] },
     },
-
     {
-      name: 'webkit',
+      name: 'webkit (desktop)',
       use: { ...devices['Desktop Safari'] },
     },
-
-    // Uncomment for mobile browsers support
-    /* {
-      name: 'Mobile Chrome',
+    {
+      name: 'webkit (tablet)',
+      use: { ...devices['iPad Mini'] },
+    },
+    {
+      name: 'chromium (mobile)',
       use: { ...devices['Pixel 5'] },
     },
     {
-      name: 'Mobile Safari',
+      name: 'webkit (mobile)',
       use: { ...devices['iPhone 12'] },
-    }, */
-
-    // Uncomment for branded browsers
-    /* {
-      name: 'Microsoft Edge',
-      use: { ...devices['Desktop Edge'], channel: 'msedge' },
     },
-    {
-      name: 'Google Chrome',
-      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    } */
   ],
 })

--- a/apps/docs-e2e/src/docs.spec.ts
+++ b/apps/docs-e2e/src/docs.spec.ts
@@ -60,6 +60,13 @@ test.describe(`Common MOBILE, TABLET and DESKTOP Layout Elements`, {
 test.describe(`Common MOBILE and TABLET Layout Elements`, {
   tag: '@smoke',
 }, () => {
+  test.beforeEach(async () => {
+    const device = test.info().project.name
+    if (device.includes('desktop')) {
+      test.skip()
+    }
+  })
+
   test(`should have quick links section visible in mobile/tablet header`, async ({ docsLayoutPage }) => {
     await expect(docsLayoutPage.quickLinks).toBeVisible()
   })
@@ -87,6 +94,9 @@ test.describe(`Common MOBILE and TABLET Menu Elements`, {
     }
     else if (device.includes('tablet')) {
       await docsLayoutPage.kebabIcon.click()
+    }
+    else {
+      test.skip()
     }
   })
 
@@ -162,6 +172,13 @@ test.describe(`Common MOBILE and TABLET Menu Elements`, {
 test.describe('Common TABLET and DESKTOP Layout Elements', {
   tag: '@smoke',
 }, () => {
+  test.beforeEach(async () => {
+    const device = test.info().project.name
+    if (device.includes('mobile')) {
+      test.skip()
+    }
+  })
+
   test(`should contain search bar in tablet/desktop header`, async ({ docsLayoutPage }) => {
     await expect(docsLayoutPage.searchBar).toBeVisible()
   })
@@ -184,6 +201,13 @@ test.describe('Common TABLET and DESKTOP Layout Elements', {
 test.describe('Unique DESKTOP Header Elements', {
   tag: '@smoke',
 }, () => {
+  test.beforeEach(async () => {
+    const device = test.info().project.name
+    if (device.includes('mobile') || device.includes('tablet')) {
+      test.skip()
+    }
+  })
+
   test('should contain Website dropdown button in desktop header', async ({ docsLayoutPage }) => {
     await expect(docsLayoutPage.websiteDropdownButton).toBeVisible()
   })
@@ -250,6 +274,13 @@ test.describe('Unique DESKTOP Header Elements', {
 test.describe('Unique Floating Table of Contents DESKTOP Elements', {
   tag: '@smoke',
 }, () => {
+  test.beforeEach(async () => {
+    const device = test.info().project.name
+    if (device.includes('mobile') || device.includes('tablet')) {
+      test.skip()
+    }
+  })
+
   test('should contain \'Edit on GitHub\' button in floating table of contents', async ({ docsLayoutPage }) => {
     await expect(docsLayoutPage.editOnGitHubButton).toBeVisible()
   })
@@ -263,6 +294,13 @@ test.describe('Unique Floating Table of Contents DESKTOP Elements', {
 test.describe('Unique MOBILE Header Elements', {
   tag: '@smoke',
 }, () => {
+  test.beforeEach(async () => {
+    const device = test.info().project.name
+    if (device.includes('desktop') || device.includes('tablet')) {
+      test.skip()
+    }
+  })
+
   test('should contain hamburger icon', async ({ docsLayoutPage }) => {
     await expect(docsLayoutPage.hamburgerIcon).toBeVisible()
   })
@@ -281,6 +319,13 @@ test.describe('Unique MOBILE Header Elements', {
 test.describe('Unique TABLET Header Elements', {
   tag: '@smoke',
 }, () => {
+  test.beforeEach(async () => {
+    const device = test.info().project.name
+    if (device.includes('desktop') || device.includes('mobile')) {
+      test.skip()
+    }
+  })
+
   test('should have kebab icon visible', async ({ docsLayoutPage }) => {
     await expect(docsLayoutPage.kebabIcon).toBeVisible()
   })

--- a/apps/docs-e2e/src/docs.spec.ts
+++ b/apps/docs-e2e/src/docs.spec.ts
@@ -25,198 +25,163 @@ const CUHACKING_2025_DOCS_URL = `${DOCS_BASE_URL}/docs`
 
 const CUHACKING_2025_LANDING_PAGE_URL = 'https://www.cuhacking.ca/'
 
-const DEVICES: { DEVICE: string, VIEWPORT: { width: number, height: number } }[] = [
-  { DEVICE: 'desktop', VIEWPORT: { width: 1024, height: 1440 } },
-  { DEVICE: 'tablet', VIEWPORT: { width: 768, height: 1024 } },
-  { DEVICE: 'mobile', VIEWPORT: { width: 320, height: 480 } },
-]
-
-const NARROW_DEVICES = DEVICES.filter(device => device.DEVICE !== 'desktop')
-const WIDE_DEVICES = DEVICES.filter(device => device.DEVICE !== 'mobile')
-
-const MOBILE_DEVICE = DEVICES.find(device => device.DEVICE === 'mobile')!
-const TABLET_DEVICE = DEVICES.find(device => device.DEVICE === 'tablet')!
-
 /* ---------------- MOBILE + DESKTOP + TABLET ---------------- */
-for (const { DEVICE, VIEWPORT } of DEVICES) {
-  test.describe(`[${DEVICE.toUpperCase()}] - Common Layout Elements`, {
-    tag: '@smoke',
-  }, () => {
-    test.beforeEach(async ({ docsLayoutPage }) => {
-      await docsLayoutPage.page.setViewportSize(VIEWPORT)
-      await docsLayoutPage.goto()
-    })
-
-    test(`should contain ${DEVICE} title page`, async ({ docsLayoutPage }) => {
-      await expect(docsLayoutPage.page).toHaveTitle(/Welcome to the Docs/)
-    })
-
-    test(`should contain cuHacking logo icon in ${DEVICE} header`, async ({ docsLayoutPage }) => {
-      await expect(docsLayoutPage.cuHackingLogoIcon).toBeVisible()
-    })
-
-    test(`should take user to docs home page when cuHacking logo icon is clicked in ${DEVICE} header`, async ({ docsLayoutPage }) => {
-      await docsLayoutPage.cuHackingLogoIcon.click()
-      await expect(docsLayoutPage.page).toHaveURL(CUHACKING_2025_DOCS_URL)
-    })
-
-    test(`should contain cuHacking logo Text in ${DEVICE} header`, async ({ docsLayoutPage }) => {
-      await expect(docsLayoutPage.cuHackingLogoText).toBeVisible()
-    })
-
-    test(`should take user to docs home page when cuHacking logo text is clicked in ${DEVICE} header`, async ({ docsLayoutPage }) => {
-      await docsLayoutPage.cuHackingLogoText.click()
-      await expect(docsLayoutPage.page).toHaveURL(CUHACKING_2025_DOCS_URL)
-    })
-
-    test(`should contain last updated text in docs page footer for ${DEVICE}`, async ({ docsLayoutPage }) => {
-      await expect(docsLayoutPage.lastUpdatedText).toBeVisible()
-    })
+test.describe(`Common MOBILE, TABLET and DESKTOP Layout Elements`, {
+  tag: '@smoke',
+}, () => {
+  test(`should contain title page`, async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.page).toHaveTitle(/Welcome to the Docs/)
   })
-}
+
+  test(`should contain cuHacking logo icon in header`, async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.cuHackingLogoIcon).toBeVisible()
+  })
+
+  test(`should take user to docs home page when cuHacking logo icon is clicked in header`, async ({ docsLayoutPage }) => {
+    await docsLayoutPage.cuHackingLogoIcon.click()
+    await expect(docsLayoutPage.page).toHaveURL(CUHACKING_2025_DOCS_URL)
+  })
+
+  test(`should contain cuHacking logo Text in header`, async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.cuHackingLogoText).toBeVisible()
+  })
+
+  test(`should take user to docs home page when cuHacking logo text is clicked in header`, async ({ docsLayoutPage }) => {
+    await docsLayoutPage.cuHackingLogoText.click()
+    await expect(docsLayoutPage.page).toHaveURL(CUHACKING_2025_DOCS_URL)
+  })
+
+  test(`should contain last updated text in docs page footer for`, async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.lastUpdatedText).toBeVisible()
+  })
+})
 
 /* ---------------- MOBILE + TABLET ---------------- */
-for (const { DEVICE, VIEWPORT } of NARROW_DEVICES) {
-  test.describe(`[${DEVICE.toUpperCase()}] - Common Mobile and Tablet Layout Elements`, {
-    tag: '@smoke',
-  }, () => {
-    test.beforeEach(async ({ docsLayoutPage }) => {
-      await docsLayoutPage.page.setViewportSize(VIEWPORT)
-      await docsLayoutPage.goto()
-    })
-
-    test(`should have quick links section visible in ${DEVICE} header`, async ({ docsLayoutPage }) => {
-      await expect(docsLayoutPage.quickLinks).toBeVisible()
-    })
-
-    test(`should have "Edit on Github" button visible in ${DEVICE} quick links`, async ({ docsLayoutPage }) => {
-      await docsLayoutPage.quickLinks.click()
-      await expect(docsLayoutPage.editOnGitHubButton).toBeVisible()
-    })
-
-    test(`should take user to github index page when "Edit on Github" button is clicked from ${DEVICE}`, async ({ docsLayoutPage }) => {
-      await docsLayoutPage.quickLinks.click()
-      await clickAndGoToPage(docsLayoutPage, docsLayoutPage.editOnGitHubButton, CUHACKING_2025_PLATFORM_GITHUB_INDEX_PAGE_URL)
-    })
+test.describe(`Common MOBILE and TABLET Layout Elements`, {
+  tag: '@smoke',
+}, () => {
+  test(`should have quick links section visible in mobile/tablet header`, async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.quickLinks).toBeVisible()
   })
-}
+
+  test(`should have "Edit on Github" button visible in mobile/tablet quick links`, async ({ docsLayoutPage }) => {
+    await docsLayoutPage.quickLinks.click()
+    await expect(docsLayoutPage.editOnGitHubButton).toBeVisible()
+  })
+
+  test(`should take user to github index page when "Edit on Github" button is clicked from mobile/tablet`, async ({ docsLayoutPage }) => {
+    await docsLayoutPage.quickLinks.click()
+    await clickAndGoToPage(docsLayoutPage, docsLayoutPage.editOnGitHubButton, CUHACKING_2025_PLATFORM_GITHUB_INDEX_PAGE_URL)
+  })
+})
 
 /* ---------------- MOBILE + TABLET MENU ---------------- */
-for (const { DEVICE, VIEWPORT } of NARROW_DEVICES) {
-  test.describe(`[${DEVICE.toUpperCase()}] - Common Mobile and Tablet Menu Elements`, {
-    tag: '@smoke',
-  }, () => {
-    test.beforeEach(async ({ docsLayoutPage }) => {
-      await docsLayoutPage.goto()
-      await docsLayoutPage.page.setViewportSize(VIEWPORT)
-      if (DEVICE === 'mobile') {
-        await docsLayoutPage.hamburgerIcon.click()
-      }
-      else if (DEVICE === 'tablet') {
-        await docsLayoutPage.kebabIcon.click()
-      }
-    })
-
-    test(`should have docs pages section dropdown menu visible for ${DEVICE}`, async ({ docsLayoutPage }) => {
-      await expect(docsLayoutPage.sectionsDropdownButton).toBeVisible()
-    })
-
-    test(`should have website button visible from website dropdown for ${DEVICE}`, async ({ docsLayoutPage }) => {
-      await docsLayoutPage.websiteDropdownButton.click()
-      await expect(docsLayoutPage.mobileWebsiteLink).toBeVisible()
-    })
-
-    test(`should take user to landing page when website button is clicked for ${DEVICE}`, async ({ docsLayoutPage }) => {
-      await docsLayoutPage.websiteDropdownButton.click()
-      await clickAndGoToPage(docsLayoutPage, docsLayoutPage.mobileWebsiteLink, CUHACKING_2025_LANDING_PAGE_URL)
-    })
-
-    test(`should have website source button visible from website dropdown for ${DEVICE}`, async ({ docsLayoutPage }) => {
-      await docsLayoutPage.websiteDropdownButton.click()
-      await expect(docsLayoutPage.mobileWebsiteSourceLink).toBeVisible()
-    })
-
-    test(`should take user to landing page repository when website source button is clicked for ${DEVICE}`, async ({ docsLayoutPage }) => {
-      await docsLayoutPage.websiteDropdownButton.click()
-      await clickAndGoToPage(docsLayoutPage, docsLayoutPage.mobileWebsiteSourceLink, CUHACKING_2025_LANDING_PAGE_GITHUB_REPOSITORY_URL)
-    })
-
-    test(`should have hacker portal app button visible from hacker portal dropdown for ${DEVICE}`, async ({ docsLayoutPage }) => {
-      await docsLayoutPage.hackerPortalDropdownButton.click()
-      await expect(docsLayoutPage.mobileHackerAppLink).toBeVisible()
-    })
-
-    test(`should take user to hacker portal app when app button is clicked for ${DEVICE}`, async ({ docsLayoutPage }) => {
-      await docsLayoutPage.hackerPortalDropdownButton.click()
-      await docsLayoutPage.mobileHackerAppLink.click()
-      await expect(docsLayoutPage.page).toHaveURL(DOCS_BASE_URL)
-    })
-
-    test(`should have hacker portal source button visible from hacker portal dropdown for ${DEVICE}`, async ({ docsLayoutPage }) => {
-      await docsLayoutPage.hackerPortalDropdownButton.click()
-      await expect(docsLayoutPage.mobileHackerPortalSourceLink).toBeVisible()
-    })
-
-    test(`should take user to hacker portal source repository when source button is clicked for ${DEVICE}`, async ({ docsLayoutPage }) => {
-      await docsLayoutPage.hackerPortalDropdownButton.click()
-      await clickAndGoToPage(docsLayoutPage, docsLayoutPage.mobileHackerPortalSourceLink, CUHACKING_2025_PLATFORM_GITHUB_REPOSITORY_URL)
-    })
-
-    test(`should have hacker portal project board button visible from hacker portal dropdown for ${DEVICE}`, async ({ docsLayoutPage }) => {
-      await docsLayoutPage.hackerPortalDropdownButton.click()
-      await expect(docsLayoutPage.mobileHackerPortalProjectBoardLink).toBeVisible()
-    })
-
-    test(`should take user to hacker portal project board when project board button is clicked ${DEVICE}`, async ({ docsLayoutPage }) => {
-      await docsLayoutPage.hackerPortalDropdownButton.click()
-      await clickAndGoToPage(docsLayoutPage, docsLayoutPage.mobileHackerPortalProjectBoardLink, CUHACKING_2025_PLATFORM_GITHUB_PROJECT_BOARD_URL)
-    })
-
-    test(`should have github button visible from ${DEVICE} menu`, async ({ docsLayoutPage }) => {
-      await expect(docsLayoutPage.mobileGithubIcon).toBeVisible()
-    })
-
-    test(`should take user to github repository when github button is clicked for ${DEVICE}`, async ({ docsLayoutPage }) => {
-      await clickAndGoToPage(docsLayoutPage, docsLayoutPage.mobileGithubIcon, CUHACKING_2025_PLATFORM_GITHUB_REPOSITORY_URL)
-    })
-
-    test(`should have theme toggle visible for ${DEVICE}`, async ({ docsLayoutPage }) => {
-      await expect(docsLayoutPage.themeToggle).toBeVisible()
-    })
+test.describe(`Common MOBILE and TABLET Menu Elements`, {
+  tag: '@smoke',
+}, () => {
+  test.beforeEach(async ({ docsLayoutPage }) => {
+    await docsLayoutPage.goto()
+    const device = test.info().project.name
+    if (device.includes('mobile')) {
+      await docsLayoutPage.hamburgerIcon.click()
+    }
+    else if (device.includes('tablet')) {
+      await docsLayoutPage.kebabIcon.click()
+    }
   })
-}
+
+  test(`should have docs pages section dropdown menu visible for mobile/tablet`, async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.sectionsDropdownButton).toBeVisible()
+  })
+
+  test(`should have website button visible from website dropdown for mobile/tablet`, async ({ docsLayoutPage }) => {
+    await docsLayoutPage.websiteDropdownButton.click()
+    await expect(docsLayoutPage.mobileWebsiteLink).toBeVisible()
+  })
+
+  test(`should take user to landing page when website button is clicked for mobile/tablet`, async ({ docsLayoutPage }) => {
+    await docsLayoutPage.websiteDropdownButton.click()
+    await clickAndGoToPage(docsLayoutPage, docsLayoutPage.mobileWebsiteLink, CUHACKING_2025_LANDING_PAGE_URL)
+  })
+
+  test(`should have website source button visible from website dropdown for mobile/tablet`, async ({ docsLayoutPage }) => {
+    await docsLayoutPage.websiteDropdownButton.click()
+    await expect(docsLayoutPage.mobileWebsiteSourceLink).toBeVisible()
+  })
+
+  test(`should take user to landing page repository when website source button is clicked for mobile/tablet`, async ({ docsLayoutPage }) => {
+    await docsLayoutPage.websiteDropdownButton.click()
+    await clickAndGoToPage(docsLayoutPage, docsLayoutPage.mobileWebsiteSourceLink, CUHACKING_2025_LANDING_PAGE_GITHUB_REPOSITORY_URL)
+  })
+
+  test(`should have hacker portal app button visible from hacker portal dropdown for mobile/tablet`, async ({ docsLayoutPage }) => {
+    await docsLayoutPage.hackerPortalDropdownButton.click()
+    await expect(docsLayoutPage.mobileHackerAppLink).toBeVisible()
+  })
+
+  test(`should take user to hacker portal app when app button is clicked for mobile/tablet`, async ({ docsLayoutPage }) => {
+    await docsLayoutPage.hackerPortalDropdownButton.click()
+    await docsLayoutPage.mobileHackerAppLink.click()
+    await expect(docsLayoutPage.page).toHaveURL(DOCS_BASE_URL)
+  })
+
+  test(`should have hacker portal source button visible from hacker portal dropdown for mobile/tablet`, async ({ docsLayoutPage }) => {
+    await docsLayoutPage.hackerPortalDropdownButton.click()
+    await expect(docsLayoutPage.mobileHackerPortalSourceLink).toBeVisible()
+  })
+
+  test(`should take user to hacker portal source repository when source button is clicked for mobile/tablet`, async ({ docsLayoutPage }) => {
+    await docsLayoutPage.hackerPortalDropdownButton.click()
+    await clickAndGoToPage(docsLayoutPage, docsLayoutPage.mobileHackerPortalSourceLink, CUHACKING_2025_PLATFORM_GITHUB_REPOSITORY_URL)
+  })
+
+  test(`should have hacker portal project board button visible from hacker portal dropdown for mobile/tablet`, async ({ docsLayoutPage }) => {
+    await docsLayoutPage.hackerPortalDropdownButton.click()
+    await expect(docsLayoutPage.mobileHackerPortalProjectBoardLink).toBeVisible()
+  })
+
+  test(`should take user to hacker portal project board when project board button is clicked mobile/tablet`, async ({ docsLayoutPage }) => {
+    await docsLayoutPage.hackerPortalDropdownButton.click()
+    await clickAndGoToPage(docsLayoutPage, docsLayoutPage.mobileHackerPortalProjectBoardLink, CUHACKING_2025_PLATFORM_GITHUB_PROJECT_BOARD_URL)
+  })
+
+  test(`should have github button visible from mobile/tablet menu`, async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.mobileGithubIcon).toBeVisible()
+  })
+
+  test(`should take user to github repository when github button is clicked for mobile/tablet`, async ({ docsLayoutPage }) => {
+    await clickAndGoToPage(docsLayoutPage, docsLayoutPage.mobileGithubIcon, CUHACKING_2025_PLATFORM_GITHUB_REPOSITORY_URL)
+  })
+
+  test(`should have theme toggle visible for mobile/tablet`, async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.themeToggle).toBeVisible()
+  })
+})
 
 /* ---------------- TABLET + DESKTOP ---------------- */
-for (const { DEVICE, VIEWPORT } of WIDE_DEVICES) {
-  test.describe(`[${DEVICE.toUpperCase()}] - Common Tablet and Desktop Layout Elements`, {
-    tag: '@smoke',
-  }, () => {
-    test.beforeEach(async ({ docsLayoutPage }) => {
-      await docsLayoutPage.page.setViewportSize(VIEWPORT)
-      await docsLayoutPage.goto()
-    })
-
-    test(`should contain search bar in ${DEVICE} header`, async ({ docsLayoutPage }) => {
-      await expect(docsLayoutPage.searchBar).toBeVisible()
-    })
-
-    test(`should show search modal when search bar clicked in ${DEVICE} header`, async ({ docsLayoutPage }) => {
-      await docsLayoutPage.searchBar.click()
-      await expect(docsLayoutPage.searchDialog).toBeVisible()
-    })
-
-    test(`should have docs pages section dropdown menu visible in ${DEVICE} sidebar`, async ({ docsLayoutPage }) => {
-      await expect(docsLayoutPage.sectionsDropdownButton).toBeVisible()
-    })
-
-    test(`should contain sidebar toggle in ${DEVICE} sidebar`, async ({ docsLayoutPage }) => {
-      await expect(docsLayoutPage.sideBarToggle).toBeVisible()
-    })
+test.describe('Common TABLET and DESKTOP Layout Elements', {
+  tag: '@smoke',
+}, () => {
+  test(`should contain search bar in tablet/desktop header`, async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.searchBar).toBeVisible()
   })
-}
+
+  test(`should show search modal when search bar clicked in tablet/desktop header`, async ({ docsLayoutPage }) => {
+    await docsLayoutPage.searchBar.click()
+    await expect(docsLayoutPage.searchDialog).toBeVisible()
+  })
+
+  test(`should have docs pages section dropdown menu visible in tablet/desktop sidebar`, async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.sectionsDropdownButton).toBeVisible()
+  })
+
+  test(`should contain sidebar toggle in tablet/desktop sidebar`, async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.sideBarToggle).toBeVisible()
+  })
+})
 
 /* ---------------- UNIQUE DESKTOP HEADER ---------------- */
-test.describe('[DESKTOP] - Unique Header Elements', {
+test.describe('Unique DESKTOP Header Elements', {
   tag: '@smoke',
 }, () => {
   test('should contain Website dropdown button in desktop header', async ({ docsLayoutPage }) => {
@@ -282,7 +247,7 @@ test.describe('[DESKTOP] - Unique Header Elements', {
 })
 
 /* ---------------- UNIQUE DESKTOP FLOATING TABLE ---------------- */
-test.describe('[DESKTOP]- Unique Floating Table of Contents Elements', {
+test.describe('Unique Floating Table of Contents DESKTOP Elements', {
   tag: '@smoke',
 }, () => {
   test('should contain \'Edit on GitHub\' button in floating table of contents', async ({ docsLayoutPage }) => {
@@ -295,14 +260,9 @@ test.describe('[DESKTOP]- Unique Floating Table of Contents Elements', {
 })
 
 /* ---------------- UNIQUE MOBILE HEADER ---------------- */
-test.describe('[MOBILE] - Unique Header Elements', {
+test.describe('Unique MOBILE Header Elements', {
   tag: '@smoke',
 }, () => {
-  test.beforeEach(async ({ docsLayoutPage }) => {
-    await docsLayoutPage.goto()
-    await docsLayoutPage.page.setViewportSize(MOBILE_DEVICE.VIEWPORT)
-  })
-
   test('should contain hamburger icon', async ({ docsLayoutPage }) => {
     await expect(docsLayoutPage.hamburgerIcon).toBeVisible()
   })
@@ -318,14 +278,9 @@ test.describe('[MOBILE] - Unique Header Elements', {
 })
 
 /* ---------------- UNIQUE TABLET HEADER ---------------- */
-test.describe('[TABLET] - Unique Header Elements', {
+test.describe('Unique TABLET Header Elements', {
   tag: '@smoke',
 }, () => {
-  test.beforeEach(async ({ docsLayoutPage }) => {
-    await docsLayoutPage.goto()
-    await docsLayoutPage.page.setViewportSize(TABLET_DEVICE.VIEWPORT)
-  })
-
   test('should have kebab icon visible', async ({ docsLayoutPage }) => {
     await expect(docsLayoutPage.kebabIcon).toBeVisible()
   })

--- a/apps/docs-e2e/src/docs.spec.ts
+++ b/apps/docs-e2e/src/docs.spec.ts
@@ -2,6 +2,8 @@ import { test as base, expect } from '@playwright/test'
 
 import { DocsLayout } from './pom'
 
+import { clickAndGoToPage } from './helpers/click-and-go-to-page'
+
 const test = base.extend<{ docsLayoutPage: DocsLayout }>({
   docsLayoutPage: async ({ page }, use) => {
     const docsLayoutPage = new DocsLayout(page)
@@ -10,35 +12,213 @@ const test = base.extend<{ docsLayoutPage: DocsLayout }>({
   },
 })
 
-const DOCS_SITE_URL = 'http://localhost:3000/docs'
-const CUHACKING_2025_PLATFORM_GITHUB_REPOSITORY_URL = 'https://github.com/cuhacking/2025'
-const CUHACKING_2025_PLATFORM_GITHUB_PROJECT_BOARD_URL = 'https://github.com/orgs/cuhacking/projects/4'
+const GITHUB_BASE_URL = 'https://github.com/cuhacking'
+const GITHUB_ORG_BASE_URL = 'https://github.com/orgs/cuhacking'
+const DOCS_BASE_URL = 'http://localhost:3000'
 
-test('should contain page title', async ({ docsLayoutPage }) => {
-  await expect(docsLayoutPage.page).toHaveTitle(/Welcome to the Docs/)
-})
+const CUHACKING_2025_PLATFORM_GITHUB_PROJECT_BOARD_URL = `${GITHUB_ORG_BASE_URL}/projects/4`
+const CUHACKING_2025_PLATFORM_GITHUB_REPOSITORY_URL = `${GITHUB_BASE_URL}/2025`
+const CUHACKING_2025_PLATFORM_GITHUB_INDEX_PAGE_URL = `${GITHUB_BASE_URL}/2025/blob/main/apps/docs/src/content/docs/index.mdx`
+const CUHACKING_2025_LANDING_PAGE_GITHUB_REPOSITORY_URL = `${GITHUB_BASE_URL}/landing-page`
 
-test.describe('should contain desktop header elements', {
+const CUHACKING_2025_DOCS_URL = `${DOCS_BASE_URL}/docs`
+
+const CUHACKING_2025_LANDING_PAGE_URL = 'https://www.cuhacking.ca/'
+
+const DEVICES: { DEVICE: string, VIEWPORT: { width: number, height: number } }[] = [
+  { DEVICE: 'desktop', VIEWPORT: { width: 1024, height: 1440 } },
+  { DEVICE: 'tablet', VIEWPORT: { width: 768, height: 1024 } },
+  { DEVICE: 'mobile', VIEWPORT: { width: 320, height: 480 } },
+]
+
+const NARROW_DEVICES = DEVICES.filter(device => device.DEVICE !== 'desktop')
+const WIDE_DEVICES = DEVICES.filter(device => device.DEVICE !== 'mobile')
+
+const MOBILE_DEVICE = DEVICES.find(device => device.DEVICE === 'mobile')!
+const TABLET_DEVICE = DEVICES.find(device => device.DEVICE === 'tablet')!
+
+/* ---------------- MOBILE + DESKTOP + TABLET ---------------- */
+for (const { DEVICE, VIEWPORT } of DEVICES) {
+  test.describe(`[${DEVICE.toUpperCase()}] - Common Layout Elements`, {
+    tag: '@smoke',
+  }, () => {
+    test.beforeEach(async ({ docsLayoutPage }) => {
+      await docsLayoutPage.page.setViewportSize(VIEWPORT)
+      await docsLayoutPage.goto()
+    })
+
+    test(`should contain ${DEVICE} title page`, async ({ docsLayoutPage }) => {
+      await expect(docsLayoutPage.page).toHaveTitle(/Welcome to the Docs/)
+    })
+
+    test(`should contain cuHacking logo icon in ${DEVICE} header`, async ({ docsLayoutPage }) => {
+      await expect(docsLayoutPage.cuHackingLogoIcon).toBeVisible()
+    })
+
+    test(`should take user to docs home page when cuHacking logo icon is clicked in ${DEVICE} header`, async ({ docsLayoutPage }) => {
+      await docsLayoutPage.cuHackingLogoIcon.click()
+      await expect(docsLayoutPage.page).toHaveURL(CUHACKING_2025_DOCS_URL)
+    })
+
+    test(`should contain cuHacking logo Text in ${DEVICE} header`, async ({ docsLayoutPage }) => {
+      await expect(docsLayoutPage.cuHackingLogoText).toBeVisible()
+    })
+
+    test(`should take user to docs home page when cuHacking logo text is clicked in ${DEVICE} header`, async ({ docsLayoutPage }) => {
+      await docsLayoutPage.cuHackingLogoText.click()
+      await expect(docsLayoutPage.page).toHaveURL(CUHACKING_2025_DOCS_URL)
+    })
+
+    test(`should contain last updated text in docs page footer for ${DEVICE}`, async ({ docsLayoutPage }) => {
+      await expect(docsLayoutPage.lastUpdatedText).toBeVisible()
+    })
+  })
+}
+
+/* ---------------- MOBILE + TABLET ---------------- */
+for (const { DEVICE, VIEWPORT } of NARROW_DEVICES) {
+  test.describe(`[${DEVICE.toUpperCase()}] - Common Mobile and Tablet Layout Elements`, {
+    tag: '@smoke',
+  }, () => {
+    test.beforeEach(async ({ docsLayoutPage }) => {
+      await docsLayoutPage.page.setViewportSize(VIEWPORT)
+      await docsLayoutPage.goto()
+    })
+
+    test(`should have quick links section visible in ${DEVICE} header`, async ({ docsLayoutPage }) => {
+      await expect(docsLayoutPage.quickLinks).toBeVisible()
+    })
+
+    test(`should have "Edit on Github" button visible in ${DEVICE} quick links`, async ({ docsLayoutPage }) => {
+      await docsLayoutPage.quickLinks.click()
+      await expect(docsLayoutPage.editOnGitHubButton).toBeVisible()
+    })
+
+    test(`should take user to github index page when "Edit on Github" button is clicked from ${DEVICE}`, async ({ docsLayoutPage }) => {
+      await docsLayoutPage.quickLinks.click()
+      await clickAndGoToPage(docsLayoutPage, docsLayoutPage.editOnGitHubButton, CUHACKING_2025_PLATFORM_GITHUB_INDEX_PAGE_URL)
+    })
+  })
+}
+
+/* ---------------- MOBILE + TABLET MENU ---------------- */
+for (const { DEVICE, VIEWPORT } of NARROW_DEVICES) {
+  test.describe(`[${DEVICE.toUpperCase()}] - Common Mobile and Tablet Menu Elements`, {
+    tag: '@smoke',
+  }, () => {
+    test.beforeEach(async ({ docsLayoutPage }) => {
+      await docsLayoutPage.goto()
+      await docsLayoutPage.page.setViewportSize(VIEWPORT)
+      if (DEVICE === 'mobile') {
+        await docsLayoutPage.hamburgerIcon.click()
+      }
+      else if (DEVICE === 'tablet') {
+        await docsLayoutPage.kebabIcon.click()
+      }
+    })
+
+    test(`should have docs pages section dropdown menu visible for ${DEVICE}`, async ({ docsLayoutPage }) => {
+      await expect(docsLayoutPage.sectionsDropdownButton).toBeVisible()
+    })
+
+    test(`should have website button visible from website dropdown for ${DEVICE}`, async ({ docsLayoutPage }) => {
+      await docsLayoutPage.websiteDropdownButton.click()
+      await expect(docsLayoutPage.mobileWebsiteLink).toBeVisible()
+    })
+
+    test(`should take user to landing page when website button is clicked for ${DEVICE}`, async ({ docsLayoutPage }) => {
+      await docsLayoutPage.websiteDropdownButton.click()
+      await clickAndGoToPage(docsLayoutPage, docsLayoutPage.mobileWebsiteLink, CUHACKING_2025_LANDING_PAGE_URL)
+    })
+
+    test(`should have website source button visible from website dropdown for ${DEVICE}`, async ({ docsLayoutPage }) => {
+      await docsLayoutPage.websiteDropdownButton.click()
+      await expect(docsLayoutPage.mobileWebsiteSourceLink).toBeVisible()
+    })
+
+    test(`should take user to landing page repository when website source button is clicked for ${DEVICE}`, async ({ docsLayoutPage }) => {
+      await docsLayoutPage.websiteDropdownButton.click()
+      await clickAndGoToPage(docsLayoutPage, docsLayoutPage.mobileWebsiteSourceLink, CUHACKING_2025_LANDING_PAGE_GITHUB_REPOSITORY_URL)
+    })
+
+    test(`should have hacker portal app button visible from hacker portal dropdown for ${DEVICE}`, async ({ docsLayoutPage }) => {
+      await docsLayoutPage.hackerPortalDropdownButton.click()
+      await expect(docsLayoutPage.mobileHackerAppLink).toBeVisible()
+    })
+
+    test(`should take user to hacker portal app when app button is clicked for ${DEVICE}`, async ({ docsLayoutPage }) => {
+      await docsLayoutPage.hackerPortalDropdownButton.click()
+      await docsLayoutPage.mobileHackerAppLink.click()
+      await expect(docsLayoutPage.page).toHaveURL(DOCS_BASE_URL)
+    })
+
+    test(`should have hacker portal source button visible from hacker portal dropdown for ${DEVICE}`, async ({ docsLayoutPage }) => {
+      await docsLayoutPage.hackerPortalDropdownButton.click()
+      await expect(docsLayoutPage.mobileHackerPortalSourceLink).toBeVisible()
+    })
+
+    test(`should take user to hacker portal source repository when source button is clicked for ${DEVICE}`, async ({ docsLayoutPage }) => {
+      await docsLayoutPage.hackerPortalDropdownButton.click()
+      await clickAndGoToPage(docsLayoutPage, docsLayoutPage.mobileHackerPortalSourceLink, CUHACKING_2025_PLATFORM_GITHUB_REPOSITORY_URL)
+    })
+
+    test(`should have hacker portal project board button visible from hacker portal dropdown for ${DEVICE}`, async ({ docsLayoutPage }) => {
+      await docsLayoutPage.hackerPortalDropdownButton.click()
+      await expect(docsLayoutPage.mobileHackerPortalProjectBoardLink).toBeVisible()
+    })
+
+    test(`should take user to hacker portal project board when project board button is clicked ${DEVICE}`, async ({ docsLayoutPage }) => {
+      await docsLayoutPage.hackerPortalDropdownButton.click()
+      await clickAndGoToPage(docsLayoutPage, docsLayoutPage.mobileHackerPortalProjectBoardLink, CUHACKING_2025_PLATFORM_GITHUB_PROJECT_BOARD_URL)
+    })
+
+    test(`should have github button visible from ${DEVICE} menu`, async ({ docsLayoutPage }) => {
+      await expect(docsLayoutPage.mobileGithubIcon).toBeVisible()
+    })
+
+    test(`should take user to github repository when github button is clicked for ${DEVICE}`, async ({ docsLayoutPage }) => {
+      await clickAndGoToPage(docsLayoutPage, docsLayoutPage.mobileGithubIcon, CUHACKING_2025_PLATFORM_GITHUB_REPOSITORY_URL)
+    })
+
+    test(`should have theme toggle visible for ${DEVICE}`, async ({ docsLayoutPage }) => {
+      await expect(docsLayoutPage.themeToggle).toBeVisible()
+    })
+  })
+}
+
+/* ---------------- TABLET + DESKTOP ---------------- */
+for (const { DEVICE, VIEWPORT } of WIDE_DEVICES) {
+  test.describe(`[${DEVICE.toUpperCase()}] - Common Tablet and Desktop Layout Elements`, {
+    tag: '@smoke',
+  }, () => {
+    test.beforeEach(async ({ docsLayoutPage }) => {
+      await docsLayoutPage.page.setViewportSize(VIEWPORT)
+      await docsLayoutPage.goto()
+    })
+
+    test(`should contain search bar in ${DEVICE} header`, async ({ docsLayoutPage }) => {
+      await expect(docsLayoutPage.searchBar).toBeVisible()
+    })
+
+    test(`should show search modal when search bar clicked in ${DEVICE} header`, async ({ docsLayoutPage }) => {
+      await docsLayoutPage.searchBar.click()
+      await expect(docsLayoutPage.searchDialog).toBeVisible()
+    })
+
+    test(`should have docs pages section dropdown menu visible in ${DEVICE} sidebar`, async ({ docsLayoutPage }) => {
+      await expect(docsLayoutPage.sectionsDropdownButton).toBeVisible()
+    })
+
+    test(`should contain sidebar toggle in ${DEVICE} sidebar`, async ({ docsLayoutPage }) => {
+      await expect(docsLayoutPage.sideBarToggle).toBeVisible()
+    })
+  })
+}
+
+/* ---------------- UNIQUE DESKTOP HEADER ---------------- */
+test.describe('[DESKTOP] - Unique Header Elements', {
   tag: '@smoke',
 }, () => {
-  test('should contain cuHacking logo icon in desktop header', async ({ docsLayoutPage }) => {
-    await expect(docsLayoutPage.cuHackingLogoIcon).toBeVisible()
-  })
-
-  test('should take user to docs home page when cuHacking logo icon is clicked', async ({ docsLayoutPage }) => {
-    await docsLayoutPage.cuHackingLogoIcon.click()
-    await expect(docsLayoutPage.page).toHaveURL(DOCS_SITE_URL)
-  })
-
-  test('should contain cuHacking logo Text in desktop header', async ({ docsLayoutPage }) => {
-    await expect(docsLayoutPage.cuHackingLogoText).toBeVisible()
-  })
-
-  test('should take user to docs home page when cuHacking logo text is clicked', async ({ docsLayoutPage }) => {
-    await docsLayoutPage.cuHackingLogoText.click()
-    await expect(docsLayoutPage.page).toHaveURL(DOCS_SITE_URL)
-  })
-
   test('should contain Website dropdown button in desktop header', async ({ docsLayoutPage }) => {
     await expect(docsLayoutPage.websiteDropdownButton).toBeVisible()
   })
@@ -65,7 +245,7 @@ test.describe('should contain desktop header elements', {
   test('should take user to Hacker Portal App when Hacker Portal App link inside Hacker Portal Dropdown is clicked', async ({ docsLayoutPage }) => {
     await docsLayoutPage.hackerPortalDropdownButton.click()
     await docsLayoutPage.hackerPortalLink.click()
-    await expect(docsLayoutPage.page).toHaveURL('http://localhost:3000')
+    await expect(docsLayoutPage.page).toHaveURL(DOCS_BASE_URL)
   })
 
   test('should contain Hacker Portal Source link inside Hacker Portal Dropdown', async ({ docsLayoutPage }) => {
@@ -75,10 +255,7 @@ test.describe('should contain desktop header elements', {
 
   test('should take user to Hacker Portal GitHub Repository when Hacker Portal App link inside Hacker Portal Dropdown is clicked', async ({ docsLayoutPage }) => {
     await docsLayoutPage.hackerPortalDropdownButton.click()
-    const pagePromise = docsLayoutPage.page.context().waitForEvent('page')
-    await docsLayoutPage.hackerPortalSourceLink.click()
-    const newPage = await pagePromise
-    await expect(newPage).toHaveURL(CUHACKING_2025_PLATFORM_GITHUB_REPOSITORY_URL)
+    await clickAndGoToPage(docsLayoutPage, docsLayoutPage.hackerPortalSourceLink, CUHACKING_2025_PLATFORM_GITHUB_REPOSITORY_URL)
   })
 
   test('should contain Hacker Portal Project Board link inside Hacker Portal Dropdown', async ({ docsLayoutPage }) => {
@@ -88,19 +265,7 @@ test.describe('should contain desktop header elements', {
 
   test('should take user to Hacker Portal Project Board when Hacker Portal App link inside Hacker Portal Dropdown is clicked', async ({ docsLayoutPage }) => {
     await docsLayoutPage.hackerPortalDropdownButton.click()
-    const pagePromise = docsLayoutPage.page.context().waitForEvent('page')
-    await docsLayoutPage.hackerPortalProjectBoardLink.click()
-    const newPage = await pagePromise
-    await expect(newPage).toHaveURL(CUHACKING_2025_PLATFORM_GITHUB_PROJECT_BOARD_URL)
-  })
-
-  test('should contain search bar in desktop header', async ({ docsLayoutPage }) => {
-    await expect(docsLayoutPage.searchBar).toBeVisible()
-  })
-
-  test('should show search modal when search bar in desktop header is clicked', async ({ docsLayoutPage }) => {
-    await docsLayoutPage.searchBar.click()
-    await expect(docsLayoutPage.searchDialog).toBeVisible()
+    await clickAndGoToPage(docsLayoutPage, docsLayoutPage.hackerPortalProjectBoardLink, CUHACKING_2025_PLATFORM_GITHUB_PROJECT_BOARD_URL)
   })
 
   test('should contain theme toggle in desktop header', async ({ docsLayoutPage }) => {
@@ -112,22 +277,12 @@ test.describe('should contain desktop header elements', {
   })
 
   test('should take user to cuHacking Hacker Portal GitHub repository when GitHub icon is clicked', async ({ docsLayoutPage }) => {
-    const pagePromise = docsLayoutPage.page.context().waitForEvent('page')
-    await docsLayoutPage.gitHubIcon.click()
-    const newPage = await pagePromise
-    await expect(newPage).toHaveURL(CUHACKING_2025_PLATFORM_GITHUB_REPOSITORY_URL)
+    await clickAndGoToPage(docsLayoutPage, docsLayoutPage.gitHubIcon, CUHACKING_2025_PLATFORM_GITHUB_REPOSITORY_URL)
   })
 })
 
-test.describe('should contain desktop sidebar elements', {
-  tag: '@smoke',
-}, () => {
-  test('should contain sidebar toggle in desktop sidebar', async ({ docsLayoutPage }) => {
-    await expect(docsLayoutPage.sideBarToggle).toBeVisible()
-  })
-})
-
-test.describe('should contain floating table of contents elements', {
+/* ---------------- UNIQUE DESKTOP FLOATING TABLE ---------------- */
+test.describe('[DESKTOP]- Unique Floating Table of Contents Elements', {
   tag: '@smoke',
 }, () => {
   test('should contain \'Edit on GitHub\' button in floating table of contents', async ({ docsLayoutPage }) => {
@@ -135,38 +290,43 @@ test.describe('should contain floating table of contents elements', {
   })
 
   test('should take user to current docs page file on the cuHacking Hacker Portal GitHub repository when the \'Edit on GitHub\' icon is clicked', async ({ docsLayoutPage }) => {
-    const pagePromise = docsLayoutPage.page.context().waitForEvent('page')
-    await docsLayoutPage.editOnGitHubButton.click()
-    const newPage = await pagePromise
-    await expect(newPage).toHaveURL(`${CUHACKING_2025_PLATFORM_GITHUB_REPOSITORY_URL}/blob/main/src/content/docs/index.mdx`)
+    await clickAndGoToPage(docsLayoutPage, docsLayoutPage.editOnGitHubButton, CUHACKING_2025_PLATFORM_GITHUB_INDEX_PAGE_URL)
   })
 })
 
-test.describe('should contain docs page elements', {
+/* ---------------- UNIQUE MOBILE HEADER ---------------- */
+test.describe('[MOBILE] - Unique Header Elements', {
   tag: '@smoke',
 }, () => {
-  test('should contain last updated text in docs page footer', async ({ docsLayoutPage }) => {
-    await expect(docsLayoutPage.lastUpdatedText).toBeVisible()
-  })
-})
-
-// TODO: complete test suite for mobile
-test.describe('should contain mobile header elements', {
-  tag: '@smoke',
-}, () => {
-  test('should contain cuHacking Logo Icon in mobile header', async ({ docsLayoutPage }) => {
-    await docsLayoutPage.page.setViewportSize({
-      width: 320,
-      height: 480,
-    })
-    await expect(docsLayoutPage.cuHackingLogoIcon).toBeVisible()
+  test.beforeEach(async ({ docsLayoutPage }) => {
+    await docsLayoutPage.goto()
+    await docsLayoutPage.page.setViewportSize(MOBILE_DEVICE.VIEWPORT)
   })
 
-  test('should contain hamburger icon in mobile header', async ({ docsLayoutPage }) => {
-    await docsLayoutPage.page.setViewportSize({
-      width: 320,
-      height: 480,
-    })
+  test('should contain hamburger icon', async ({ docsLayoutPage }) => {
     await expect(docsLayoutPage.hamburgerIcon).toBeVisible()
+  })
+
+  test('should contain search icon', async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.searchIcon).toBeVisible()
+  })
+
+  test('should show search modal when search icon is clicked', async ({ docsLayoutPage }) => {
+    await docsLayoutPage.searchIcon.click()
+    await expect(docsLayoutPage.searchModal).toBeVisible()
+  })
+})
+
+/* ---------------- UNIQUE TABLET HEADER ---------------- */
+test.describe('[TABLET] - Unique Header Elements', {
+  tag: '@smoke',
+}, () => {
+  test.beforeEach(async ({ docsLayoutPage }) => {
+    await docsLayoutPage.goto()
+    await docsLayoutPage.page.setViewportSize(TABLET_DEVICE.VIEWPORT)
+  })
+
+  test('should have kebab icon visible', async ({ docsLayoutPage }) => {
+    await expect(docsLayoutPage.kebabIcon).toBeVisible()
   })
 })

--- a/apps/docs-e2e/src/helpers/click-and-go-to-page.ts
+++ b/apps/docs-e2e/src/helpers/click-and-go-to-page.ts
@@ -1,0 +1,9 @@
+import type { Locator, Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+export async function clickAndGoToPage(layout: { page: Page }, button: Locator, expectedUrl: string) {
+  const pagePromise = layout.page.context().waitForEvent('page')
+  await button.click()
+  const newPage = await pagePromise
+  await expect(newPage).toHaveURL(expectedUrl)
+}

--- a/apps/docs-e2e/src/pom.ts
+++ b/apps/docs-e2e/src/pom.ts
@@ -22,6 +22,18 @@ export class DocsLayout {
 
   // Mobile Header
   readonly hamburgerIcon: Locator
+  readonly searchIcon: Locator
+  readonly searchModal: Locator
+  readonly quickLinks: Locator
+
+  // Mobile + Tablet Elements
+  readonly sectionsDropdownButton: Locator
+  readonly mobileWebsiteLink: Locator
+  readonly mobileHackerPortalSourceLink: Locator
+  readonly mobileHackerAppLink: Locator
+  readonly mobileWebsiteSourceLink: Locator
+  readonly mobileGithubIcon: Locator
+  readonly mobileHackerPortalProjectBoardLink: Locator
 
   // Desktop Sidebar
   readonly sideBarToggle: Locator
@@ -34,6 +46,9 @@ export class DocsLayout {
 
   // Search Dialog
   readonly searchDialog: Locator
+
+  // Tablet Header
+  readonly kebabIcon: Locator
 
   constructor(page: Page) {
     this.page = page
@@ -57,6 +72,18 @@ export class DocsLayout {
 
     // Mobile Header
     this.hamburgerIcon = page.getByLabel('Toggle Sidebar')
+    this.searchIcon = page.getByRole('button', { name: 'Open Search' })
+    this.searchModal = page.getByPlaceholder('Search')
+    this.quickLinks = page.getByRole('button', { name: 'On this page Quick Links' })
+
+    // Mobile + Tablet Elements
+    this.sectionsDropdownButton = page.getByRole('button', { name: 'Home Leave none behind' })
+    this.mobileWebsiteLink = page.getByRole('link', { name: 'Website' })
+    this.mobileHackerPortalSourceLink = page.getByRole('link', { name: 'Source', exact: true })
+    this.mobileHackerAppLink = page.getByRole('link', { name: 'App' })
+    this.mobileWebsiteSourceLink = page.getByRole('link', { name: 'Source (legacy)' })
+    this.mobileGithubIcon = page.getByRole('link', { name: 'Github' })
+    this.mobileHackerPortalProjectBoardLink = page.getByRole('link', { name: 'Project Board' })
 
     // Desktop Sidebar
     this.sideBarToggle = page.getByLabel('Collapse Sidebar')
@@ -69,6 +96,9 @@ export class DocsLayout {
 
     // Search Dialog
     this.searchDialog = page.getByRole('dialog').getByPlaceholder('Search')
+
+    // Tablet Header
+    this.kebabIcon = page.locator('#nd-nav').getByRole('button').nth(1)
   }
 
   async goto() {

--- a/apps/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/[[...slug]]/page.tsx
@@ -23,7 +23,7 @@ export default async function Page({
   const footer = (
     <>
       <a
-        href={`${gitHubRepoUrl}/blob/main/${path}`}
+        href={`${gitHubRepoUrl}/blob/main/apps/docs/${path}`}
         target="_blank"
         rel="noreferrer noopener"
         className="inline-flex items-center justify-center rounded-md font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border bg-fd-secondary text-fd-secondary-foreground hover:bg-fd-secondary/80 h-9 px-3 text-xs gap-1.5"

--- a/apps/docs/tailwind.config.ts
+++ b/apps/docs/tailwind.config.ts
@@ -1,6 +1,6 @@
 // TODO: Delete this file once no longer needed as a reference
 import type { Config } from 'tailwindcss'
-import { fontFamily } from 'tailwindcss/defaultTheme'
+// import { fontFamily } from 'tailwindcss/defaultTheme'
 import { createPreset } from 'fumadocs-ui/tailwind-plugin'
 
 export default {


### PR DESCRIPTION
- Added mobile and tablet layout tests (by following a similar suite of tests for desktop)
- Needed to use Playwright Codegen (had to use the page variable instead of docsLayoutPage) for specific interactions with elements that are unavailable to desktop (i.e., hamburger icon, 3 dots, etc.)
- Used beforeEach tests as well to properly initialize mobile and tablet layouts
- Updated docs home page ``Edit on GitHub`` button href in order to run successful tests for that link

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add mobile and tablet layout tests for the documentation site using Playwright, ensuring compatibility and functionality across different device sizes. Update the 'Edit on GitHub' button href to facilitate successful test execution.

New Features:
- Introduce mobile and tablet layout tests for the documentation site using Playwright.

Enhancements:
- Update the 'Edit on GitHub' button href on the docs home page to ensure successful test execution.

Tests:
- Add comprehensive test suites for mobile and tablet layouts, including checks for page titles, header elements, and interactive components like the hamburger icon and search functionality.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced test reliability with automatic retries for flaky tests.
	- Added new device-specific project configurations for improved clarity.
	- Introduced a utility function for streamlined navigation in tests.
	- Expanded UI element management for mobile and tablet interfaces in the documentation layout.
	- Improved test execution workflow with separate commands for each test suite and enhanced reporting capabilities.

- **Bug Fixes**
	- Corrected URL paths in documentation links to ensure accurate navigation.

- **Documentation**
	- Improved test suite organization for better coverage across mobile, tablet, and desktop views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->