### PR TITLE
style(docs-e2e): added comments for test

### DIFF
--- a/apps/docs-e2e/src/example.spec.ts
+++ b/apps/docs-e2e/src/example.spec.ts
@@ -4,5 +4,6 @@ test('has title', async ({ page }) => {
   await page.goto('/')
 
   // Expect h1 to contain a substring.
+  // See https://playwright.dev/docs/api/class-locator#locator-textcontent
   expect(await page.locator('h1').textContent()).toContain('Welcome')
 })


### PR DESCRIPTION
This is a test pr. I only added a comment

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a comment in the e2e test file to provide a reference to the Playwright documentation for better understanding of the textContent method usage.

Documentation:
- Add a comment in the e2e test file to reference the Playwright documentation for the textContent method.

<!-- Generated by sourcery-ai[bot]: end summary -->