### PR TITLE
ci(release): enforcing v24.x for semantic-release CLI in RELEASE workflow

### DIFF
--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -33,7 +33,7 @@ jobs:
       - name: 🤖 Run Semantic Release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: pnpm i; pnpm semantic-release
+        run: pnpm i; pnpm semantic-release@24
 
       - name: 💰 Profit
         run: echo 🐞


### PR DESCRIPTION
Enforcing the semantic-release CLI version in your pipelines will avoid builds from breaking when a new major version of semantic-release is released.

This is highlighted in the docs: https://semantic-release.gitbook.io/semantic-release/usage/installation#global-installation:~:text=If%20you%27ve%20globally,semantic%2Drelease.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the `semantic-release` package used in the release process to version 24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->