### PR TITLE
KHasith/docs/overhaul outdated content

### DIFF
--- a/apps/docs/src/content/docs/contribution-guidelines/conventional-commits.mdx
+++ b/apps/docs/src/content/docs/contribution-guidelines/conventional-commits.mdx
@@ -31,6 +31,11 @@ The slight learning curve of writing conventional commits is well worth the effo
 
 ### Commit Message Decision Tree
 
+<Callout type="warn" title="Use pnpm commit!">
+  `pnpm commit` will guide you through writing a conventional commit message. Use it until you are comfortable with conventional commit guidelines.
+</Callout>
+
+
 #### Type
 
 ```mermaid

--- a/apps/docs/src/content/docs/contribution-guidelines/index.mdx
+++ b/apps/docs/src/content/docs/contribution-guidelines/index.mdx
@@ -168,6 +168,13 @@ pnpm i
   </div>
 
   <div className="step">
+    Install [playwright](https://playwright.dev/) browsers.
+    ```sh title="terminal"
+    pnpm exec playwright install
+    ```
+  </div>
+
+  <div className="step">
     Spin up development docker containers, one of which contains the PostgreSQL database.
 
     ```sh title="terminal"

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -20,18 +20,21 @@ import { pages } from "../../app/(docs)/source";
 
 <Cards>
   <Card
-    title="Notion Workspace"
+    title={"GitHub Projects"}
     description={
       <>
-        <li>Central hub of operations for the cuHacking team.</li>
-        <li>Invite required for access.</li>
+        <li>Tracking issues, tasks, and progress directly within GitHub.</li>
+        <li>
+          Allows everyone to see what everyone else is up to, and do work
+          without blocking each other.
+        </li>
       </>
     }
-    href={`https://www.notion.so/`}
+    href={`https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects`}
     icon={
       <img
-        src="https://upload.wikimedia.org/wikipedia/commons/e/e9/Notion-logo.svg"
-        alt="Notion Logo"
+        src="https://www.logo.wine/a/logo/GitHub/GitHub-Icon-White-Dark-Background-Logo.wine.svg"
+        alt="GitHub Logo"
         width={24}
         height={24}
       />

--- a/apps/docs/src/content/docs/knowledge-base/nextauth.mdx
+++ b/apps/docs/src/content/docs/knowledge-base/nextauth.mdx
@@ -2,6 +2,10 @@
 title: NextAuth.js Flow
 description: Documenting authorization and authentication in our platform
 ---
+<Callout type="warn" title="We don't use NextAuth!">
+  cuHacking opts for a different authentication library (TBD), this page is for reference only.
+</Callout>
+
 ## ⚙️Setup for NextAuth
 
 ### Create your prisma models

--- a/apps/docs/src/content/docs/tools-overview/index.mdx
+++ b/apps/docs/src/content/docs/tools-overview/index.mdx
@@ -360,61 +360,12 @@ Written in a beginner-friendly language in order to provide a smooth onboarding 
 ### ⁉️ State Management
 
 <Cards>
-  <Card
-    title={"Redux"}
-    description={
-      <>
-        <li>Purpose-built and highly opinionated state management library.</li>
-        <li>
-          Lots of documentation, large community, and rich ecosystem of plugins.
-        </li>
-        <li>
-          Helps you manage variables that are highly susceptible to change, and
-          upon which lots of other variables may depend on.
-        </li>
-        <li>
-          Separates state management from the React view layer and other
-          business logic entirely, and therefore scales well + easy to debug.
-        </li>
-      </>
-    }
-    href={`https://redux.js.org/`}
-    icon={
-      <img
-        src="https://www.svgrepo.com/show/303557/redux-logo.svg"
-        alt="Redux Logo"
-        width={24}
-        height={24}
-      />
-    }
-  />
+  
 </Cards>
 
 ### ⚙️ Back-End & Middleware
 
 <Cards>
-  <Card
-    title={'Lucia Auth'}
-    description={
-      <>
-        <li>Handling authentication safely and securely.</li>
-        <li>
-          Allows people to log in to our app with pre-existing
-          Google/Microsoft/Apple accounts, saving us from having to deal with
-          their sensitive data.
-        </li>
-      </>
-    }
-    href={`https://lucia-auth.com/`}
-    icon={
-      <img
-        src="https://avatars.githubusercontent.com/u/124423533?s=200&v=4.png"
-        alt="Lucia Auth Logo"
-        width={24}
-        height={24}
-      />
-    }
-  />
   <Card
     title={'tRPC'}
     description={
@@ -859,41 +810,6 @@ Written in a beginner-friendly language in order to provide a smooth onboarding 
     }
   />
   <Card
-    title={"Vercel (being replaced by Netlify)"}
-    description={
-      <>
-        <li>
-          For safely deploying our app to the web so that people can see and use
-          it from their browsers.
-        </li>
-        <li>
-          Uses <a href="https://aws.amazon.com/">AWS</a> under the hood.
-        </li>
-        <li>
-          Integrates well with Next.js and also allows for demo deployments for
-          our own purposes which are not indexed on google.
-        </li>
-        <li>
-          If we push a version that makes it past all our tests but somehow
-          breaks at the build stage, Vercel will provide instant feedback and
-          not deploy it, leaving up the previous functional version.
-        </li>
-        <li>
-          Also allows quick and easy rollbacks to previously deployed versions.
-        </li>
-      </>
-    }
-    href={`https://vercel.com/`}
-    icon={
-      <img
-        src="https://avatars.githubusercontent.com/u/14985020?s=200&v=4.svg"
-        alt="Vercel Logo"
-        width={24}
-        height={24}
-      />
-    }
-  />
-  <Card
     title={"Netlify"}
     description={
       <>
@@ -923,47 +839,6 @@ Written in a beginner-friendly language in order to provide a smooth onboarding 
       <img
         src="https://avatars.githubusercontent.com/u/7892489?s=200&v=4.svg"
         alt="Netlify Logo"
-        width={24}
-        height={24}
-      />
-    }
-  />
-  <Card
-    title={"Terraform"}
-    description={
-      <>
-        <li>Open-source infrastructure as code software tool.</li>
-        <li>Define and provision data center infrastructure with code.</li>
-      </>
-    }
-    href={`https://www.terraform.io`}
-    icon={
-      <img
-        src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/terraform/terraform-original.svg"
-        alt="Terraform Logo"
-        width={24}
-        height={24}
-      />
-    }
-  />
-  <Card
-    title={"AWS"}
-    description={
-      <>
-        <li>
-          Definitely uses <a href="https://aws.amazon.com/">AWS</a> under the
-          hood.
-        </li>
-        <li>
-          Provisioning and managing variety of cloud services for our apps.
-        </li>
-      </>
-    }
-    href={`https://aws.amazon.com`}
-    icon={
-      <img
-        src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/amazonwebservices/amazonwebservices-plain-wordmark.svg"
-        alt="AWS Logo"
         width={24}
         height={24}
       />

--- a/apps/docs/src/content/docs/tools-overview/index.mdx
+++ b/apps/docs/src/content/docs/tools-overview/index.mdx
@@ -360,7 +360,32 @@ Written in a beginner-friendly language in order to provide a smooth onboarding 
 ### ⁉️ State Management
 
 <Cards>
-  
+    <Card
+    title={"XState"}
+    description={
+    <>
+      <li>Powerful and flexible state management library based on finite state machines and statecharts.</li>
+      <li>
+        Strong focus on predictability and control over state transitions, allowing for more reliable and well-defined workflows.
+      </li>
+      <li>
+        Ideal for managing complex or multi-step processes, where each state and transition can be explicitly defined and visualized.
+      </li>
+      <li>
+        Separates business logic from UI, making it framework-agnostic and easy to integrate with React, Vue, and other libraries.
+      </li>
+    </> 
+    }
+    href={`https://stately.ai/docs/xstate`}
+    icon={
+      <img
+        src="https://www.svgrepo.com/show/354581/xstate.svg"
+        alt="Redux Logo"
+        width={24}
+        height={24}
+      />
+    }
+  />
 </Cards>
 
 ### ⚙️ Back-End & Middleware


### PR DESCRIPTION
## Why were these changes made?
Our doc site was outdated and external contributors were not able to contribute effectively.

##  What are the changes?
- Updated quick-start setup
- remove unused technologies
- Added reminders throughout the docs site where necessary. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a warning callout in the Conventional Commits document to guide users on using the `pnpm commit` command.
	- Updated installation instructions to include Playwright browser installation for new contributors.
	- Introduced a new "XState" card and a "tRPC" card in the tools overview, replacing outdated options.
	- Added a warning in the NextAuth document clarifying the platform's authentication library usage.

- **Documentation**
	- Restructured and clarified various sections across multiple documents for improved user guidance and flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->