### PR TITLE
feat(storybook): add fumadocs ui components

### DIFF
--- a/apps/docs/tailwind.config.js
+++ b/apps/docs/tailwind.config.js
@@ -7,6 +7,7 @@ import TailwindAnimate from 'tailwindcss-animate'
 export default {
   content: [
     '../../libs/docs/components/**/*.{ts,tsx}',
+    '../../libs/docs/components/**/*.stories.{ts,tsx}',
     './mdx-components.{ts,tsx}',
     '{src,components,app,content}/**/*!(*.stories|*.spec).{ts,tsx,md,mdx,html}',
     '../../node_modules/fumadocs-ui/dist/**/*.js',

--- a/libs/docs/components/ui/accordion.stories.tsx
+++ b/libs/docs/components/ui/accordion.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Accordion, Accordions } from 'fumadocs-ui/components/accordion'
+
+const meta: Meta<typeof Accordion> = {
+  title: '📚 Docs Site/Accordion',
+  component: Accordion,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'The title of the accordion',
+    },
+    asChild: {
+      control: 'boolean',
+      description: 'Renders the component as a child element',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Disables the accordion',
+      defaultValue: false,
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Accordion>
+
+export const Default: Story = {
+  args: {
+    title: 'What is Fumadocs?',
+    asChild: false,
+    disabled: false,
+  },
+  render: args => (
+    <Accordions>
+      <Accordion {...args}>Fumadocs is a documentation UI toolkit.</Accordion>
+      <Accordion title="What do we love?" {...args}>
+        We love clean and efficient documentation!
+      </Accordion>
+    </Accordions>
+  ),
+}
+
+export const Disabled: Story = {
+  args: {
+    title: 'What is Fumadocs?',
+    asChild: false,
+    disabled: true,
+  },
+  render: args => (
+    <Accordions>
+      <Accordion {...args}>This accordion is disabled.</Accordion>
+    </Accordions>
+  ),
+}
+
+export const Multiple: Story = {
+  args: {
+    title: 'What is Fumadocs?',
+    asChild: false,
+    disabled: false,
+  },
+  render: args => (
+    <Accordions type="multiple">
+      <Accordion {...args}>Fumadocs is a documentation UI toolkit.</Accordion>
+      <Accordion title="What do we love?" {...args}>
+        We love clean and efficient documentation!
+      </Accordion>
+    </Accordions>
+  ),
+}

--- a/libs/docs/components/ui/callout.stories.tsx
+++ b/libs/docs/components/ui/callout.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Callout } from 'fumadocs-ui/components/callout'
+
+const meta: Meta<typeof Callout> = {
+  title: '📚 Docs Site/Callout',
+  parameters: {
+    layout: 'centered',
+  },
+  component: Callout,
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      options: ['info', 'warn', 'error'],
+      control: { type: 'select' },
+      description: 'The type of callout (info, warn, error)',
+    },
+    title: {
+      control: 'text',
+      description: 'The title of the callout',
+    },
+    children: {
+      control: 'text',
+      description: 'The content inside the callout',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Callout>
+
+export const Default: Story = {
+  args: {
+    title: 'Callout',
+    type: 'info',
+    children: 'This is a default callout. You can edit this text.',
+  },
+  render: args => (
+    <div>
+      <Callout {...args}>{args.children}</Callout>
+    </div>
+  ),
+}
+
+export const Warn: Story = {
+  args: {
+    title: 'Warn Callout',
+    type: 'warn',
+    children: 'This is a warning callout. Pay attention to this message.',
+  },
+  render: args => (
+    <div>
+      <Callout {...args}>{args.children}</Callout>
+    </div>
+  ),
+}
+
+export const Error: Story = {
+  args: {
+    title: 'Error Callout',
+    type: 'error',
+    children: 'This is an error callout. Action may be required.',
+  },
+  render: args => (
+    <div>
+      <Callout {...args}>{args.children}</Callout>
+    </div>
+  ),
+}

--- a/libs/docs/components/ui/card.stories.tsx
+++ b/libs/docs/components/ui/card.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Card } from 'fumadocs-ui/components/card'
+import { HomeIcon } from 'lucide-react'
+
+const meta: Meta<typeof Card> = {
+  title: '📚 Docs Site/Card',
+  parameters: {
+    layout: 'centered',
+  },
+  component: Card,
+  tags: ['autodocs'],
+  argTypes: {
+    icon: {
+      control: 'boolean',
+      description: 'Toggle to show or hide the icon',
+    },
+    title: {
+      control: 'text',
+      description: 'The title of the card',
+    },
+    description: {
+      control: 'text',
+      description: 'The description text for the card',
+    },
+    href: {
+      control: 'text',
+      description: 'The destination URL when the card is clicked',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Card>
+
+export const Default: Story = {
+  args: {
+    title: 'Title',
+    description: 'Description',
+    href: 'https://fumadocs.vercel.app/docs/ui/mdx/card#card',
+    icon: true,
+  },
+  render: args => (
+    <div>
+      <Card
+        {...args}
+        icon={args.icon ? <HomeIcon /> : undefined}
+      />
+    </div>
+  ),
+}
+
+export const WithoutHref: Story = {
+  args: {
+    title: 'Title',
+    description: 'This card does not have a destination URL',
+    icon: true,
+  },
+  render: args => (
+    <div>
+      <Card
+        {...args}
+        icon={args.icon ? <HomeIcon /> : undefined}
+      />
+    </div>
+  ),
+}

--- a/libs/docs/components/ui/folder.stories.tsx
+++ b/libs/docs/components/ui/folder.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { File, Files, Folder } from 'fumadocs-ui/components/files'
+
+const meta: Meta<typeof Files> = {
+  title: '📚 Docs Site/Files',
+  component: Files,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    name: {
+      control: 'text',
+      description: 'The name of the file or folder',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Disables the folder interaction',
+      defaultValue: false,
+    },
+    icon: {
+      control: 'object',
+      description: 'Optional icon component to display',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Files>
+
+export const Default: Story = {
+  render: () => (
+    <Files>
+      <Folder name="app" defaultOpen>
+        <Folder name="[id]">
+          <File name="page.tsx" />
+        </Folder>
+        <File name="layout.tsx" />
+        <File name="page.tsx" />
+        <File name="global.css" />
+      </Folder>
+      <Folder name="components">
+        <File name="button.tsx" />
+        <File name="tabs.tsx" />
+        <File name="dialog.tsx" />
+      </Folder>
+      <File name="package.json" />
+    </Files>
+  ),
+}
+
+export const FolderDisabled: Story = {
+  render: () => (
+    <Files>
+      <Folder name="app" disabled>
+        <File name="layout.tsx" />
+        <File name="page.tsx" />
+      </Folder>
+      <Folder name="components" disabled>
+        <File name="button.tsx" />
+        <File name="dialog.tsx" />
+      </Folder>
+    </Files>
+  ),
+}
+
+export const CustomIcons: Story = {
+  render: () => (
+    <Files>
+      <Folder name="app" defaultOpen icon={<span>📁</span>}>
+        <File name="layout.tsx" icon={<span>📄</span>} />
+        <File name="page.tsx" icon={<span>📄</span>} />
+      </Folder>
+      <Folder name="components" icon={<span>⚙️</span>}>
+        <File name="button.tsx" icon={<span>🛠️</span>} />
+        <File name="dialog.tsx" icon={<span>🛠️</span>} />
+      </Folder>
+      <File name="package.json" icon={<span>📦</span>} />
+    </Files>
+  ),
+}

--- a/libs/docs/components/ui/tabs.stories.tsx
+++ b/libs/docs/components/ui/tabs.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs'
+
+const meta: Meta<typeof Tabs> = {
+  title: '📚 Docs Site/Tabs',
+  component: Tabs,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    items: {
+      control: 'array',
+      description: 'The list of tab items',
+      defaultValue: ['Javascript', 'Rust', 'Typescript'],
+    },
+    defaultIndex: {
+      control: 'number',
+      description: 'The default active tab index',
+      defaultValue: 0,
+    },
+    persist: {
+      control: 'boolean',
+      description: 'Persist active tab state in localStorage',
+      defaultValue: false,
+    },
+    groupId: {
+      control: 'text',
+      description: 'The group id for persistent tabs (used as localStorage key)',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Tabs>
+
+export const Default: Story = {
+  args: {
+    items: ['Javascript', 'Rust', 'Typescript'],
+    defaultIndex: 0,
+  },
+  render: args => (
+    <Tabs items={args.items} defaultIndex={args.defaultIndex}>
+      <Tab value="Javascript">Hello World in Javascript</Tab>
+      <Tab value="Rust">Rust is fast</Tab>
+      <Tab value="Typescript">Typescript is great for typing</Tab>
+    </Tabs>
+  ),
+}
+
+export const Persistent: Story = {
+  args: {
+    items: ['Javascript', 'Rust'],
+    persist: true,
+    groupId: 'language',
+  },
+  render: args => (
+    <Tabs items={args.items} persist groupId={args.groupId}>
+      <Tab value="Javascript">Value is shared! Try refreshing to see persistence.</Tab>
+      <Tab value="Rust">Rust is fast and persistent!</Tab>
+    </Tabs>
+  ),
+}
+
+export const DefaultValue: Story = {
+  args: {
+    items: ['Javascript', 'Rust'],
+    defaultIndex: 1,
+  },
+  render: args => (
+    <Tabs items={args.items} defaultIndex={args.defaultIndex}>
+      <Tab value="Javascript">Javascript is weird</Tab>
+      <Tab value="Rust">Rust is fast</Tab>
+    </Tabs>
+  ),
+}

--- a/libs/docs/components/ui/type-table.stories.tsx
+++ b/libs/docs/components/ui/type-table.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { TypeTable } from 'fumadocs-ui/components/type-table'
+
+const meta: Meta<typeof TypeTable> = {
+  title: '📚 Docs Site/Type Table',
+  component: TypeTable,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    type: {
+      control: 'object',
+      description: 'The object describing the types and their properties',
+      defaultValue: {
+        percentage: {
+          description: 'The percentage of scroll position to display the roll button',
+          type: 'number',
+          default: 0.2,
+        },
+      },
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof TypeTable>
+
+export const Default: Story = {
+  args: {
+    type: {
+      percentage: {
+        description: 'The percentage of scroll position to display the roll button',
+        type: 'number',
+        default: 0.2,
+      },
+    },
+  },
+  render: args => <TypeTable {...args} />,
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,6 +3,7 @@ import TailwindAnimate from 'tailwindcss-animate'
 export default {
   content: [
     '{libs,apps}/**/*!(*.stories|*.spec).{ts,tsx,html}',
+    './node_modules/fumadocs-ui/dist/**/*.js',
   ],
   theme: {
     extend: {
@@ -78,11 +79,11 @@ export default {
         'orbit': {
           '0%': {
             transform:
-                'rotate(0deg) translateY(calc(var(--radius) * 1px)) rotate(0deg)',
+              'rotate(0deg) translateY(calc(var(--radius) * 1px)) rotate(0deg)',
           },
           '100%': {
             transform:
-                'rotate(360deg) translateY(calc(var(--radius) * 1px)) rotate(-360deg)',
+              'rotate(360deg) translateY(calc(var(--radius) * 1px)) rotate(-360deg)',
           },
         },
       },


### PR DESCRIPTION
# Pull Request Template

## PR Requirements Checklist

- [x] Commit messages follow [guidelines](https://docs.cuhacking.ca/contribution-guidelines/conventional-commits)
- [ ] Tests added
- [x] Tests pass
- [ ] Docs added/updated (for bug fixes/features)
- [x] Rebased onto main
- [x] Tested for mobile/tablet/desktop (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced Storybook configurations for the `Callout`, `Card`, `Accordion`, `Files`, `Tabs`, and `TypeTable` components.
	- Added new story variations for each component, including `Default`, `Warn`, `Error`, `Icon`, `WithoutHref`, `Disabled`, `Multiple`, `FolderDisabled`, `CustomIcons`, `Persistent`, and `DefaultValue`.
	- Expanded Tailwind CSS configuration to include additional story files for better styling support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->