### PR TITLE
docs(overview): add open source Carleton projects 

### DIFF
--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -212,6 +212,30 @@ allowFullScreen>
     href={`https://coursefull.app`}
   />
 </Cards>
+<Card
+    title="cuBlueprint"
+    description={
+      <>
+        <li>Thomas Nolasque</li>
+        <li>James Yap</li>
+        <li>Lei Wu</li>
+        <li>Hasith De Alwis</li>
+        <li>Justin Zhang</li>
+        <li>Anjali Patel</li>
+        <li>Alleena Elias</li>
+        <li>Anirudh Mahesh</li>
+        <li>Ashwin Srirankan</li>
+      </>
+    }
+    href={`https://cublueprint.org`}
+    icon={
+    <img
+    src="https://cublueprint.org/favicon.ico"
+    alt="cuBlueprint Logo"
+    width={24}
+    height={24}
+    />}
+      />
 
 ### University of Ottawa
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -211,7 +211,6 @@ allowFullScreen>
     }
     href={`https://coursefull.app`}
   />
-</Cards>
 <Card
     title="cuBlueprint"
     description={
@@ -236,6 +235,24 @@ allowFullScreen>
     height={24}
     />}
       />
+  <Card
+    title="cu-webring"
+    description={
+      <>
+        <li>Yufeng Liu</li>
+        <li>Raphaël Onana</li>
+      </>
+    }
+    href={`https://cu-webring.org`}
+    icon={
+    <img
+    src="https://cu-webring.org/assets/carleton_logo.svg"
+    alt="Carleton Logo"
+    width={24}
+    height={24}
+    />}
+      />
+</Cards>
 
 ### University of Ottawa
 


### PR DESCRIPTION
<!-- ========================= -->
<!-- ci(template/pull-request) -->
<!-- ========================= -->
<!-- Ensure PR title matches issue title -->
<!-- For example: -->
<!-- Issue -> fix(portal/header): clicking resources button goes to sponsors page instead of resources page -->
<!-- Branch -> mfarabi/fix/157-clicking-resources-button-goes-to-sponsors-page-instead-of-resources-page -->
<!-- Pull Request -> fix(portal/header): clicking resources button goes to sponsors page instead of resources page -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help. -->

- [x] I've thoroughly read the latest [contribution guidelines](https://docs.cuhacking.ca/contribution-guidelines/getting-started).
- [x] I've rebased my branch onto `main` **before** creating this PR.
- [ ] I've added tests to cover my changes (if applicable).
- [ ] I've verified that all new and existing tests have passed locally for mobile, tablet, and desktop screen sizes.
- [x] My commit messages follow [guidelines](https://docs.cuhacking.ca/concepts/conventional-commits)
- [ ] My change requires documentation updates.
- [x] I've updated the documentation accordingly.
- [x] My code follows existing patterns of this project and/or improves upon them.

---

<!-- ## Screenshots -->

<!-- | Before             | After             | -->
<!-- | ------------------ | ----------------- | -->
<!-- | Before screenshots | After screenshots | -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced two new information cards in the documentation's Open-Source Student Communities section.
	- The first card, "cuBlueprint," highlights community details, contributor names, and includes a direct link and icon.
	- The second card, "cu-webring," similarly presents community information with contributor details, a link, and an icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->